### PR TITLE
[Producer][Synchronized] Improve perform call performances

### DIFF
--- a/octobot_channels/producer.pxd
+++ b/octobot_channels/producer.pxd
@@ -16,6 +16,7 @@
 #  License along with this library.
 
 from octobot_channels.channels.channel cimport Channel
+from octobot_channels.consumer cimport Consumer
 
 cdef class Producer:
     cdef public Channel channel
@@ -27,3 +28,4 @@ cdef class Producer:
 
     cpdef void create_task(self)
     cpdef bint is_consumers_queue_empty(self, int priority_level)
+    cpdef object _get_synchronized_consumers(self, int priority_level)

--- a/octobot_channels/producer.py
+++ b/octobot_channels/producer.py
@@ -121,13 +121,19 @@ class Producer:
         Empties the queue synchronously for each consumers
         :param priority_level: the consumer minimal priority level
         """
-        for consumer in [
-            consumer
-            for consumer in self.channel.get_consumers()
-            if consumer.priority_level <= priority_level
-        ]:
+        for consumer in self._get_synchronized_consumers(priority_level):
             while not consumer.queue.empty():
                 await consumer.perform(await consumer.queue.get())
+
+    def _get_synchronized_consumers(self, priority_level):
+        """
+        Yield the consumers to be refreshed by synchronized_perform_consumers_queue
+        :param priority_level: the consumer minimal priority level
+        :return: consumers to be refreshed
+        """
+        for consumer in self.channel.get_consumers():
+            if consumer.priority_level <= priority_level:
+                yield consumer
 
     async def stop(self) -> None:
         """


### PR DESCRIPTION
Profiling (python sources only) for the same backtesting setup : 
- Before : 128ms (average of 5 profiling)
- After : 110ms (average of 5 profiling)

Will also be [significantly improved we the cpdef in the compiled version](https://stackoverflow.com/questions/50362802/how-to-type-generator-function-in-cython).