### PR TITLE
[SupervisedConsumer] add ability to join current perform task

### DIFF
--- a/async_channel/consumer.pxd
+++ b/async_channel/consumer.pxd
@@ -30,4 +30,4 @@ cdef class InternalConsumer(Consumer):
     pass
 
 cdef class SupervisedConsumer(Consumer):
-    pass
+    cdef public object idle  # object type = asyncio.Event

--- a/async_channel/consumer.py
+++ b/async_channel/consumer.py
@@ -160,6 +160,7 @@ class SupervisedConsumer(Consumer):
     """
     A SupervisedConsumer is a classic Consumer that notifies the queue when its work is done
     """
+
     def __init__(
         self,
         callback: object,

--- a/async_channel/producer.py
+++ b/async_channel/producer.py
@@ -119,7 +119,9 @@ class Producer:
             *(consumer.join_queue() for consumer in self.channel.get_consumers())
         )
 
-    async def synchronized_perform_consumers_queue(self, priority_level, join_consumers, timeout) -> None:
+    async def synchronized_perform_consumers_queue(
+        self, priority_level, join_consumers, timeout
+    ) -> None:
         """
         Empties the queue synchronously for each consumers
         :param priority_level: the consumer minimal priority level

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,6 +29,10 @@ class EmptyTestConsumer(channel_consumer.Consumer):
     pass
 
 
+class EmptyTestSupervisedConsumer(channel_consumer.SupervisedConsumer):
+    pass
+
+
 class EmptyTestProducer(producer.Producer):
     async def start(self):
         await asyncio.sleep(100000)
@@ -50,12 +54,12 @@ async def empty_test_callback():
 
 
 async def mock_was_called_once(mocked_method):
-    await _wait_asyncio_next_cycle()
+    await wait_asyncio_next_cycle()
     mocked_method.assert_called_once()
 
 
 async def mock_was_not_called(mocked_method):
-    await _wait_asyncio_next_cycle()
+    await wait_asyncio_next_cycle()
     mocked_method.assert_not_called()
 
 
@@ -68,7 +72,7 @@ class EmptyTestWithIdChannel(channels.Channel):
         self.chan_id = test_id
 
 
-async def _wait_asyncio_next_cycle():
+async def wait_asyncio_next_cycle():
     async def do_nothing():
         pass
     await asyncio.create_task(do_nothing())

--- a/tests/test_synchronized.py
+++ b/tests/test_synchronized.py
@@ -13,7 +13,9 @@
 #
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
-import mock 
+import asyncio
+
+import mock
 import pytest
 
 import async_channel.channels as channels
@@ -60,8 +62,83 @@ async def test_producer_synchronized_perform_consumers_queue_with_one_consumer(s
     with mock.patch.object(test_consumer, 'callback', new=mock.AsyncMock()) as mocked_test_consumer_callback:
         await producer.send({})
         await tests.mock_was_not_called(mocked_test_consumer_callback)
-        await producer.synchronized_perform_consumers_queue(1)
+        await producer.synchronized_perform_consumers_queue(1, True, 1)
         await tests.mock_was_called_once(mocked_test_consumer_callback)
+
+
+@pytest.mark.asyncio
+async def test_producer_synchronized_perform_supervised_consumer_with_processing_empty_queue(synchronized_channel):
+    continue_event = asyncio.Event()
+    calls = []
+    done_calls = []
+
+    async def callback():
+        calls.append(None)
+        await asyncio.wait_for(continue_event.wait(), 1)
+        done_calls.append(None)
+
+    async def set_event_task():
+        continue_event.set()
+
+    # use supervised consumers
+    synchronized_channel.CONSUMER_CLASS = tests.EmptyTestSupervisedConsumer
+    test_consumer = await synchronized_channel.new_consumer(callback)
+
+    producer = SynchronizedProducerTest(channels.get_chan(TEST_SYNCHRONIZED_CHANNEL))
+    await producer.run()
+
+    await producer.send({})
+    await test_consumer.run()
+    try:
+        await tests.wait_asyncio_next_cycle()
+        # called already yet
+        assert calls == [None]
+        # call not finished
+        assert done_calls == []
+        # queue is empty
+        assert test_consumer.queue.qsize() == 0
+        asyncio.create_task(set_event_task())
+        # wait for call to finish even though queue is empty => does not work as we are not joining the
+        # current processing
+        await producer.synchronized_perform_consumers_queue(1, False, 1)
+        assert done_calls == []
+        # wait for call to finish even though queue is empty with join
+        await producer.synchronized_perform_consumers_queue(1, True, 1)
+        # ensure call actually finished (if we did not join the current task, this call would not have finished)
+        assert done_calls == [None]
+    finally:
+        await test_consumer.stop()
+
+
+@pytest.mark.asyncio
+async def test_join():
+    # just test this does not throw an error on base consumers
+    base_consumer = tests.EmptyTestConsumer(None)
+    await base_consumer.join(1)
+
+    supervised_consumer = tests.EmptyTestSupervisedConsumer(None)
+    assert supervised_consumer.idle.is_set()
+
+    with mock.patch.object(supervised_consumer.idle, "wait", mock.AsyncMock()) as wait_mock:
+        await supervised_consumer.join(1)
+        wait_mock.assert_not_called()
+
+        supervised_consumer.idle.clear()
+        await supervised_consumer.join(1)
+        wait_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_join_queue():
+    base_consumer = tests.EmptyTestConsumer(None)
+    with mock.patch.object(base_consumer.queue, "join", mock.AsyncMock()) as join_mock:
+        await base_consumer.join_queue()
+        join_mock.assert_not_called()
+
+    supervised_consumer = tests.EmptyTestSupervisedConsumer(None)
+    with mock.patch.object(supervised_consumer.queue, "join", mock.AsyncMock()) as join_mock:
+        await supervised_consumer.join_queue()
+        join_mock.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -91,7 +168,7 @@ async def test_is_consumers_queue_empty_with_one_consumer(synchronized_channel):
     await producer.send({})
     assert not producer.is_consumers_queue_empty(1)
     assert not producer.is_consumers_queue_empty(2)
-    await producer.synchronized_perform_consumers_queue(1)
+    await producer.synchronized_perform_consumers_queue(1, True, 1)
     assert producer.is_consumers_queue_empty(1)
     assert producer.is_consumers_queue_empty(2)
 
@@ -114,17 +191,17 @@ async def test_is_consumers_queue_empty_with_multiple_consumers(synchronized_cha
     assert not producer.is_consumers_queue_empty(1)
     assert not producer.is_consumers_queue_empty(2)
     assert not producer.is_consumers_queue_empty(3)
-    await producer.synchronized_perform_consumers_queue(1)
+    await producer.synchronized_perform_consumers_queue(1, True, 1)
     assert producer.is_consumers_queue_empty(1)
     assert not producer.is_consumers_queue_empty(2)
     assert not producer.is_consumers_queue_empty(3)
-    await producer.synchronized_perform_consumers_queue(2)
+    await producer.synchronized_perform_consumers_queue(2, True, 1)
     assert producer.is_consumers_queue_empty(1)
     assert producer.is_consumers_queue_empty(2)
     assert not producer.is_consumers_queue_empty(3)
-    await producer.synchronized_perform_consumers_queue(2)
+    await producer.synchronized_perform_consumers_queue(2, True, 1)
     assert not producer.is_consumers_queue_empty(3)
-    await producer.synchronized_perform_consumers_queue(3)
+    await producer.synchronized_perform_consumers_queue(3, True, 1)
     assert producer.is_consumers_queue_empty(3)
 
 
@@ -153,20 +230,20 @@ async def test_producer_synchronized_perform_consumers_queue_with_multiple_consu
         await tests.mock_was_not_called(mocked_test_consumer_2_1_callback)
         await tests.mock_was_not_called(mocked_test_consumer_2_2_callback)
         await tests.mock_was_not_called(mocked_test_consumer_3_1_callback)
-        await producer.synchronized_perform_consumers_queue(1)
+        await producer.synchronized_perform_consumers_queue(1, True, 1)
         await tests.mock_was_called_once(mocked_test_consumer_1_1_callback)
         await tests.mock_was_called_once(mocked_test_consumer_1_2_callback)
         await tests.mock_was_not_called(mocked_test_consumer_2_1_callback)
         await tests.mock_was_not_called(mocked_test_consumer_2_2_callback)
         await tests.mock_was_not_called(mocked_test_consumer_3_1_callback)
-        await producer.synchronized_perform_consumers_queue(2)
+        await producer.synchronized_perform_consumers_queue(2, True, 1)
         await tests.mock_was_called_once(mocked_test_consumer_1_1_callback)
         await tests.mock_was_called_once(mocked_test_consumer_1_2_callback)
         await tests.mock_was_called_once(mocked_test_consumer_2_1_callback)
         await tests.mock_was_called_once(mocked_test_consumer_2_2_callback)
         await tests.mock_was_not_called(mocked_test_consumer_3_1_callback)
         assert not producer.is_consumers_queue_empty(3)
-        await producer.synchronized_perform_consumers_queue(3)
+        await producer.synchronized_perform_consumers_queue(3, True, 1)
         await tests.mock_was_called_once(mocked_test_consumer_3_1_callback)
         assert producer.is_consumers_queue_empty(1)
         assert producer.is_consumers_queue_empty(2)
@@ -184,7 +261,7 @@ async def test_producer_synchronized_perform_consumers_queue_with_multiple_consu
         await tests.mock_was_not_called(mocked_test_consumer_2_2_callback)
         await tests.mock_was_not_called(mocked_test_consumer_3_1_callback)
         assert not producer.is_consumers_queue_empty(2)
-        await producer.synchronized_perform_consumers_queue(3)
+        await producer.synchronized_perform_consumers_queue(3, True, 1)
         await tests.mock_was_called_once(mocked_test_consumer_1_1_callback)
         await tests.mock_was_called_once(mocked_test_consumer_1_2_callback)
         await tests.mock_was_called_once(mocked_test_consumer_2_1_callback)


### PR DESCRIPTION
Issue was: on backtesting, we don't wait for current "perform" tasks when they are started before the "synchronized_perform_consumers_queue" call. In this case, they are not waited for and it can end up in tasks unfinished when a next backtesting iteration is started.

This fix has almost no impact on performances (around +40ms in a 4s backtesting, aka +1%)